### PR TITLE
Set secret key via GITHUB_APP_PRIVATE_KEY_SECRET_NAME

### DIFF
--- a/parameter/parameter.go
+++ b/parameter/parameter.go
@@ -113,11 +113,15 @@ func handleEnvVars(parameter *Parameter) (string, string, error) {
 	if gitHubAppPrivateKeySecretName == "" {
 		return "", "", fmt.Errorf("GITHUB_APP_PRIVATE_KEY_SECRET_NAME variable is required")
 	}
-	secrets, err := secret.FetchSecret(gitHubAppPrivateKeySecretName)
+	gitHubAppPrivateKeySecretKey := os.Getenv("GITHUB_APP_PRIVATE_KEY_SECRET_KEY")
+	if gitHubAppPrivateKeySecretKey == "" {
+		// as default value for backward compatibility
+		gitHubAppPrivateKeySecretKey = "GitHubAppPrivateKey"
+	}
+	parameter.GitHubAppPrivateKey, err = secret.FetchSecretValue(gitHubAppPrivateKeySecretName, gitHubAppPrivateKeySecretKey)
 	if err != nil {
 		return "", "", err
 	}
-	parameter.GitHubAppPrivateKey = secrets.GitHubAppPrivateKey
 
 	parameter.GitHubAPIBaseURL = os.Getenv("GITHUB_API_BASE_URL")
 	if parameter.GitHubAPIBaseURL == "" {

--- a/secret/secret.go
+++ b/secret/secret.go
@@ -7,12 +7,8 @@ import (
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
 )
 
-type Secret struct {
-	GitHubAppPrivateKey string `json:"GitHubAppPrivateKey"`
-}
-
-func FetchSecret(secretName string) (*Secret, error) {
-	retVal := new(Secret)
+func FetchSecretValue(secretName string, secretKey string) (string, error) {
+	retVal := ""
 
 	smSession, err := session.NewSession()
 	if err != nil {
@@ -28,10 +24,12 @@ func FetchSecret(secretName string) (*Secret, error) {
 		return retVal, err
 	}
 
-	err = json.Unmarshal(([]byte)(*getSecretValueResp.SecretString), retVal)
+	var secret map[string]string
+	err = json.Unmarshal(([]byte)(*getSecretValueResp.SecretString), &secret)
 	if err != nil {
 		return retVal, err
 	}
+	retVal = secret[secretKey]
 
 	return retVal, nil
 }


### PR DESCRIPTION
Now we can set secret key when this app fetches a private key from AWS Secrets Manager. 

The default key is `GitHubAppPrivateKey`, so we keep the backward compatibility.